### PR TITLE
Handle login and logout through the main site, even when initiating via subsite

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -237,8 +237,8 @@ class Auth {
 		// This is a fully registered user. Log them in.
 		$this->set_sso_authentication_cookie( $user );
 
-		if ( isset( $_REQUEST['RelayState'] ) ) {
-			wp_safe_redirect( esc_url( $_REQUEST['RelayState'] ) );
+		if ( isset( $_REQUEST['RelayState'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			wp_safe_redirect( esc_url( $_REQUEST['RelayState'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			exit;
 		}
 

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -236,6 +236,12 @@ class Auth {
 
 		// This is a fully registered user. Log them in.
 		$this->set_sso_authentication_cookie( $user );
+
+		if ( isset( $_REQUEST['RelayState'] ) ) {
+			wp_safe_redirect( esc_url( $_REQUEST['RelayState'] ) );
+			exit;
+		}
+
 		wp_safe_redirect( home_url() );
 		exit;
 	}

--- a/src/Config.php
+++ b/src/Config.php
@@ -18,7 +18,13 @@ class Config {
 	 * @return string
 	 */
 	public static function login_url(): string {
-		return get_home_url( null, 'sso/login' );
+		if ( is_multisite() && is_main_site() ) {
+			return network_home_url( 'sso/login' );
+		}
+
+		$login_url = add_query_arg( 'sid', get_current_blog_id(), network_home_url( 'sso/login' ) );
+
+		return $login_url;
 	}
 
 	/**

--- a/src/Config.php
+++ b/src/Config.php
@@ -42,7 +42,7 @@ class Config {
 	 * @return string
 	 */
 	public static function logout_url(): string {
-		return get_home_url( null, 'sso/logout' );
+		return network_home_url( 'sso/logout' );
 	}
 
 	/**

--- a/src/Init.php
+++ b/src/Init.php
@@ -50,8 +50,17 @@ class Init {
 		$path = $path ? untrailingslashit( $path ) : '';
 
 		if ( '/sso/login' === $path ) {
+			if ( isset( $_GET['sid'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$return_url = get_home_url( absint( $_GET['sid'] ) );
+			} else {
+				$return_url = home_url();
+			}
+
 			$auth = new Auth();
-			$auth->saml()->login();
+
+			// The return URL is sent to the IDP and then returned back to this
+			// site as the RelayState parameter in POST data.
+			$auth->saml()->login( esc_url( $return_url ) );
 			exit;
 		}
 

--- a/src/Init.php
+++ b/src/Init.php
@@ -51,7 +51,7 @@ class Init {
 
 		if ( '/sso/login' === $path ) {
 			if ( isset( $_GET['sid'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				$return_url = get_home_url( absint( $_GET['sid'] ) );
+				$return_url = get_home_url( absint( $_GET['sid'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			} else {
 				$return_url = home_url();
 			}


### PR DESCRIPTION
This takes advantage of SAML's `RelayState` to communicate the URL to use in a redirect after a successful authentication.

Now, a visitor at `https://example.org/subsite/` can click the login link, navigate to `https://example.org/sso/login?sid={x}`, and then return to `https://example.org/subsite/` once authenticated.